### PR TITLE
Add AI-driven stock analysis skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Frontend
+NEXT_PUBLIC_API_BASE=http://localhost:8000
+
+# Backend
+PROVIDER=YAHOO
+OPENAI_API_KEY=
+REDIS_URL=redis://localhost:6379/0

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# WEBSITE-v1
-I DKNOW
+# AI-Driven Stock Analysis Web App
+
+Monorepo containing a Next.js frontend and FastAPI backend for real-time stock analysis, trend detection and AI Q&A.
+
+## Structure
+
+```
+apps/
+  frontend/  # Next.js 14 app
+  backend/   # FastAPI service
+```
+
+## Requirements
+
+- Node.js 20+
+- Python 3.11+
+- Redis (optional)
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in values.
+2. Backend:
+   ```bash
+   cd apps/backend
+   pip install -r requirements.txt  # optional, Docker installs automatically
+   uvicorn main:app --reload
+   ```
+3. Frontend:
+   ```bash
+   cd apps/frontend
+   npm install
+   npm run dev
+   ```
+4. Visit `http://localhost:3000`.
+
+## Docker
+
+```
+docker compose up --build
+```
+
+## Providers
+
+The default provider uses Yahoo Finance HTTP polling. To add a new real-time provider, implement the `DataProvider` protocol in `apps/backend/data/provider_base.py` and update `core/config.py`.
+
+## Notes
+
+- Saudi tickers require the `.SR` suffix (e.g. `2222.SR`).
+- The demo AI endpoint streams responses via SSE. Provide an `OPENAI_API_KEY` in the `.env` to enable real answers.
+- Trend calculations use EMA slope, MACD histogram, RSI bias and ADX strength.
+
+This project is a simplified foundation intended for extension and experimentation.

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir fastapi uvicorn[standard] httpx pandas pandas_ta numpy aioredis
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/backend/api/routes_ai.py
+++ b/apps/backend/api/routes_ai.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from typing import AsyncIterator
+
+import httpx
+from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+
+from ..core.config import get_settings
+from ..models.ai import AskRequest
+from ..models.market import Candle, Technicals, TrendResult
+from ..services.trend import trend_from_candles
+from ..services.indicators import indicators
+from ..data.provider_yahoo import YahooProvider
+import pandas as pd
+
+router = APIRouter(prefix="/api/ai")
+settings = get_settings()
+provider = YahooProvider()
+
+
+async def _openai_stream(prompt: str) -> AsyncIterator[str]:
+    url = "https://api.openai.com/v1/chat/completions"
+    headers = {
+        "Authorization": f"Bearer {settings.openai_api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": "gpt-4o-mini",
+        "stream": True,
+        "messages": [
+            {"role": "system", "content": "You are a professional market analyst."},
+            {"role": "user", "content": prompt},
+        ],
+    }
+    async with httpx.AsyncClient(timeout=None) as client:
+        async with client.stream("POST", url, headers=headers, json=payload) as resp:
+            async for line in resp.aiter_lines():
+                if line.startswith("data:"):
+                    yield line[5:].strip()
+
+
+@router.post("/ask")
+async def ai_ask(req: AskRequest) -> StreamingResponse:
+    if not settings.openai_api_key:
+        async def fake() -> AsyncIterator[bytes]:
+            yield b"data: OpenAI API key not configured\n\n"
+            yield b"data: [DONE]\n\n"
+        return StreamingResponse(fake(), media_type="text/event-stream")
+
+    candles = await provider.get_history(req.symbol, req.timeframe, "30d")
+    df = pd.DataFrame([c.dict() for c in candles])
+    tech = indicators(df)
+    trend = trend_from_candles(df)
+    context = {"technicals": tech, "trend": trend}
+    prompt = f"Context: {json.dumps(context)}\nQuestion: {req.question}"
+
+    async def event_gen() -> AsyncIterator[bytes]:
+        async for chunk in _openai_stream(prompt):
+            yield f"data: {chunk}\n\n".encode()
+        yield b"data: [DONE]\n\n"
+
+    return StreamingResponse(event_gen(), media_type="text/event-stream")

--- a/apps/backend/api/routes_market.py
+++ b/apps/backend/api/routes_market.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+import pandas as pd
+
+from ..core.cache import cache
+from ..data.provider_yahoo import YahooProvider
+from ..models.market import Candle, Quote, Technicals, TrendResult
+from ..services.indicators import indicators
+from ..services.trend import trend_from_candles
+
+router = APIRouter(prefix="/api")
+provider = YahooProvider()
+
+
+@router.get("/quote", response_model=Quote)
+async def get_quote(symbol: str) -> Quote:
+    key = f"quote:{symbol}"
+    data = await cache.get(key)
+    if data:
+        return Quote.parse_raw(data)
+    q = await provider.get_quote(symbol)
+    await cache.set(key, q.json(), ttl=10)
+    return q
+
+
+@router.get("/history", response_model=list[Candle])
+async def get_history(symbol: str, interval: str = "1d", lookback: str = "1mo") -> list[Candle]:
+    candles = await provider.get_history(symbol, interval, lookback)
+    return candles
+
+
+@router.get("/technicals", response_model=Technicals)
+async def get_technicals(symbol: str, interval: str = "1d", lookback: str = "1mo") -> Technicals:
+    candles = await provider.get_history(symbol, interval, lookback)
+    df = pd.DataFrame([c.dict() for c in candles])
+    ind = indicators(df)
+    return Technicals(**ind)
+
+
+@router.get("/trend", response_model=TrendResult)
+async def get_trend(symbol: str, interval: str = "1d", lookback: str = "1mo") -> TrendResult:
+    candles = await provider.get_history(symbol, interval, lookback)
+    if len(candles) < 50:
+        raise HTTPException(status_code=400, detail="Not enough data")
+    df = pd.DataFrame([c.dict() for c in candles])
+    result = trend_from_candles(df)
+    return TrendResult(**result)

--- a/apps/backend/core/cache.py
+++ b/apps/backend/core/cache.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Optional
+
+try:
+    import aioredis  # type: ignore
+except Exception:  # pragma: no cover - optional
+    aioredis = None
+
+from .config import get_settings
+
+
+class Cache:
+    def __init__(self) -> None:
+        settings = get_settings()
+        self.redis_url = settings.redis_url
+        self._local: dict[str, tuple[Any, float]] = {}
+        self._redis = None
+        if self.redis_url and aioredis is not None:
+            try:
+                self._redis = aioredis.from_url(self.redis_url, encoding="utf-8", decode_responses=True)
+            except Exception:
+                self._redis = None
+
+    async def get(self, key: str) -> Optional[Any]:
+        if self._redis is not None:
+            return await self._redis.get(key)
+        data = self._local.get(key)
+        if not data:
+            return None
+        value, expires = data
+        if expires < time.time():
+            del self._local[key]
+            return None
+        return value
+
+    async def set(self, key: str, value: Any, ttl: int) -> None:
+        if self._redis is not None:
+            await self._redis.set(key, value, ex=ttl)
+            return
+        self._local[key] = (value, time.time() + ttl)
+
+
+cache = Cache()

--- a/apps/backend/core/config.py
+++ b/apps/backend/core/config.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    provider: str = "YAHOO"
+    openai_api_key: str | None = None
+    redis_url: str | None = None
+
+    class Config:
+        env_file = ".env"
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/apps/backend/data/provider_base.py
+++ b/apps/backend/data/provider_base.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Protocol, AsyncIterator, List
+
+from ..models.market import Quote, Candle
+
+
+class DataProvider(Protocol):
+    async def get_quote(self, symbol: str) -> Quote:
+        ...
+
+    async def get_history(self, symbol: str, interval: str, lookback: str) -> List[Candle]:
+        ...
+
+    async def stream_quotes(self, symbols: list[str]) -> AsyncIterator[Quote]:
+        ...

--- a/apps/backend/data/provider_yahoo.py
+++ b/apps/backend/data/provider_yahoo.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import AsyncIterator, List
+
+import httpx
+
+from ..models.market import Candle, Quote
+from .provider_base import DataProvider
+
+
+YAHOO_QUOTE_URL = "https://query1.finance.yahoo.com/v7/finance/quote"
+YAHOO_CHART_URL = "https://query1.finance.yahoo.com/v8/finance/chart/{symbol}"
+
+
+class YahooProvider(DataProvider):
+    async def get_quote(self, symbol: str) -> Quote:
+        async with httpx.AsyncClient() as client:
+            r = await client.get(YAHOO_QUOTE_URL, params={"symbols": symbol})
+            r.raise_for_status()
+            result = r.json()["quoteResponse"]["result"][0]
+            price = float(result["regularMarketPrice"])
+            prev = float(result.get("previousClose", price))
+            change = price - prev
+            change_percent = (change / prev * 100.0) if prev else 0.0
+            return Quote(
+                symbol=result["symbol"],
+                price=price,
+                open=float(result.get("regularMarketOpen", price)),
+                high=float(result.get("regularMarketDayHigh", price)),
+                low=float(result.get("regularMarketDayLow", price)),
+                prev_close=prev,
+                change=change,
+                change_percent=change_percent,
+                ts=datetime.fromtimestamp(result["regularMarketTime"], tz=timezone.utc),
+            )
+
+    async def get_history(self, symbol: str, interval: str, lookback: str) -> List[Candle]:
+        async with httpx.AsyncClient() as client:
+            r = await client.get(
+                YAHOO_CHART_URL.format(symbol=symbol),
+                params={"interval": interval, "range": lookback},
+            )
+            r.raise_for_status()
+            data = r.json()["chart"]["result"][0]
+            timestamps = data["timestamp"]
+            quotes = data["indicators"]["quote"][0]
+            candles: List[Candle] = []
+            for i, ts in enumerate(timestamps):
+                candles.append(
+                    Candle(
+                        ts=datetime.fromtimestamp(ts, tz=timezone.utc),
+                        open=float(quotes["open"][i]),
+                        high=float(quotes["high"][i]),
+                        low=float(quotes["low"][i]),
+                        close=float(quotes["close"][i]),
+                        volume=float(quotes["volume"][i]),
+                    )
+                )
+            return candles
+
+    async def stream_quotes(self, symbols: list[str]) -> AsyncIterator[Quote]:
+        while True:
+            for s in symbols:
+                yield await self.get_quote(s)
+            await asyncio.sleep(1)

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .api.routes_market import router as market_router
+from .api.routes_ai import router as ai_router
+
+app = FastAPI(title="Stock Analysis API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(market_router)
+app.include_router(ai_router)
+
+
+@app.get("/")
+async def root() -> dict[str, str]:
+    return {"status": "ok"}

--- a/apps/backend/models/ai.py
+++ b/apps/backend/models/ai.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class AskRequest(BaseModel):
+    symbol: str
+    timeframe: str
+    question: str

--- a/apps/backend/models/market.py
+++ b/apps/backend/models/market.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pydantic import BaseModel
+from typing import Literal
+
+
+class Quote(BaseModel):
+    symbol: str
+    price: float
+    open: float
+    high: float
+    low: float
+    prev_close: float
+    change: float
+    change_percent: float
+    ts: datetime
+
+
+class Candle(BaseModel):
+    ts: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+
+class Technicals(BaseModel):
+    rsi: float
+    macd: float
+    macd_signal: float
+    macd_hist: float
+    adx: float
+    ema20: float
+    ema50: float
+    ema200: float
+
+
+class TrendResult(BaseModel):
+    label: Literal['Uptrend', 'Downtrend', 'Ranging']
+    score: float
+    confidence: float
+    reasons: list[str]

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn[standard]
+httpx
+pandas
+pandas_ta
+numpy
+aioredis
+pytest

--- a/apps/backend/services/indicators.py
+++ b/apps/backend/services/indicators.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+import pandas_ta as ta
+
+
+def indicators(df: pd.DataFrame) -> Dict[str, float]:
+    out: Dict[str, float] = {}
+    out["ema20"] = float(ta.ema(df.close, 20).iloc[-1])
+    out["ema50"] = float(ta.ema(df.close, 50).iloc[-1])
+    out["ema200"] = float(ta.ema(df.close, 200).iloc[-1])
+    r = ta.rsi(df.close, 14)
+    out["rsi"] = float(r.iloc[-1])
+    m = ta.macd(df.close, 12, 26, 9)
+    out["macd"] = float(m["MACD_12_26_9"].iloc[-1])
+    out["macd_signal"] = float(m["MACDs_12_26_9"].iloc[-1])
+    out["macd_hist"] = float(m["MACDh_12_26_9"].iloc[-1])
+    a = ta.adx(high=df.high, low=df.low, close=df.close, length=14)
+    out["adx"] = float(a["ADX_14"].iloc[-1])
+    return out

--- a/apps/backend/services/trend.py
+++ b/apps/backend/services/trend.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+from .indicators import indicators
+
+
+def trend_from_candles(df: pd.DataFrame) -> Dict[str, object]:
+    ind = indicators(df)
+    ema20_series = df.close.ewm(span=20, adjust=False).mean()
+    y = ema20_series.tail(20).values
+    x = np.arange(len(y))
+    slope = np.polyfit(x, y, 1)[0]
+    slope_norm = float(slope / (df.close.tail(20).std() + 1e-8))
+
+    macd_hist_z = float(
+        ind["macd_hist"] / (df.close.pct_change().rolling(50).std().iloc[-1] + 1e-6)
+    )
+    rsi_bias = (ind["rsi"] - 50.0) / 50.0
+    adx_strength = min(ind["adx"], 50) / 50.0
+
+    score = 0.35 * slope_norm + 0.30 * macd_hist_z + 0.20 * rsi_bias + 0.15 * adx_strength
+    label = "Uptrend" if score > 0.4 else ("Downtrend" if score < -0.4 else "Ranging")
+    conf = min(1.0, abs(score))
+    reasons: list[str] = []
+    if slope_norm > 0:
+        reasons.append("EMA20 slope rising")
+    else:
+        reasons.append("EMA20 slope falling")
+    if ind["macd_hist"] > 0:
+        reasons.append("MACD histogram > 0")
+    else:
+        reasons.append("MACD histogram < 0")
+    if ind["rsi"] > 55:
+        reasons.append("RSI above 55")
+    elif ind["rsi"] < 45:
+        reasons.append("RSI below 45")
+    if ind["adx"] > 20:
+        reasons.append("Trend strength (ADX) > 20")
+    return {
+        "label": label,
+        "score": float(score),
+        "confidence": float(conf),
+        "reasons": reasons,
+    }

--- a/apps/backend/tests/test_trend.py
+++ b/apps/backend/tests/test_trend.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from ..main import app
+from ..api import routes_market, routes_ai
+from ..models.market import Candle, Quote
+from ..services.trend import trend_from_candles
+
+
+def _generate_df(slope: float) -> pd.DataFrame:
+    close = np.linspace(100, 100 + slope * 99, 100)
+    df = pd.DataFrame(
+        {
+            "open": close,
+            "high": close + 1,
+            "low": close - 1,
+            "close": close,
+            "volume": np.ones_like(close),
+        }
+    )
+    return df
+
+
+def _candles_from_df(df: pd.DataFrame) -> list[Candle]:
+    candles: list[Candle] = []
+    for idx, row in df.iterrows():
+        candles.append(
+            Candle(
+                ts=pd.Timestamp("2024-01-01") + pd.Timedelta(minutes=idx),
+                open=row.open,
+                high=row.high,
+                low=row.low,
+                close=row.close,
+                volume=row.volume,
+            )
+        )
+    return candles
+
+
+class DummyProvider:
+    def __init__(self, df: pd.DataFrame) -> None:
+        self.df = df
+        self.candles = _candles_from_df(df)
+
+    async def get_quote(self, symbol: str) -> Quote:  # pragma: no cover - unused in tests
+        return Quote(
+            symbol=symbol,
+            price=float(self.df.close.iloc[-1]),
+            open=float(self.df.open.iloc[0]),
+            high=float(self.df.high.max()),
+            low=float(self.df.low.min()),
+            prev_close=float(self.df.close.iloc[-2]),
+            change=float(self.df.close.iloc[-1] - self.df.close.iloc[-2]),
+            change_percent=0.0,
+            ts=pd.Timestamp("2024-01-01"),
+        )
+
+    async def get_history(self, symbol: str, interval: str, lookback: str) -> list[Candle]:
+        return self.candles
+
+    async def stream_quotes(self, symbols: list[str]):  # pragma: no cover - unused
+        yield await self.get_quote(symbols[0])
+
+
+@pytest.fixture
+def uptrend_provider(monkeypatch):
+    df = _generate_df(1)
+    prov = DummyProvider(df)
+    routes_market.provider = prov
+    routes_ai.provider = prov
+    return prov
+
+
+def test_trend_from_candles_uptrend():
+    df = _generate_df(1)
+    result = trend_from_candles(df)
+    assert result["label"] == "Uptrend"
+    assert result["score"] > 0
+
+
+def test_trend_api(uptrend_provider):
+    client = TestClient(app)
+    resp = client.get("/api/trend", params={"symbol": "TEST"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["label"] == "Uptrend"

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+CMD ["npm", "start"]

--- a/apps/frontend/app/api/ai/stream/route.ts
+++ b/apps/frontend/app/api/ai/stream/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const data = await req.json();
+  const resp = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/api/ai/ask`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return new Response(resp.body, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+    },
+  });
+}

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -1,0 +1,15 @@
+import '../styles/globals.css';
+import { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-50">
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </body>
+    </html>
+  );
+}

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link';
+import SymbolSearch from '../components/SymbolSearch';
+
+export default function Home() {
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Stock Analysis</h1>
+      <SymbolSearch />
+      <p className="text-sm text-gray-500">Enter a symbol to view details.</p>
+    </main>
+  );
+}

--- a/apps/frontend/app/symbols/[symbol]/page.tsx
+++ b/apps/frontend/app/symbols/[symbol]/page.tsx
@@ -1,0 +1,15 @@
+import TrendBadge from '../../../components/TrendBadge';
+import MetricsGrid from '../../../components/MetricsGrid';
+import AiChat from '../../../components/AiChat';
+
+export default function SymbolPage({ params }: { params: { symbol: string } }) {
+  const { symbol } = params;
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">{symbol}</h1>
+      <TrendBadge symbol={symbol} />
+      <MetricsGrid symbol={symbol} />
+      <AiChat symbol={symbol} timeframe="1d" />
+    </main>
+  );
+}

--- a/apps/frontend/components/AiChat.tsx
+++ b/apps/frontend/components/AiChat.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function AiChat({ symbol, timeframe }: { symbol: string; timeframe: string }) {
+  const [messages, setMessages] = useState<string[]>([]);
+  const [question, setQuestion] = useState('');
+
+  const ask = async () => {
+    const res = await fetch('/api/ai/stream', {
+      method: 'POST',
+      body: JSON.stringify({ symbol, timeframe, question }),
+    });
+    if (!res.body) return;
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      setMessages((prev) => [...prev, buffer]);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="max-h-60 overflow-y-auto border p-2 text-sm">
+        {messages.map((m, i) => (
+          <p key={i}>{m}</p>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          className="flex-1 border px-2 py-1"
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          placeholder="Ask about the symbol"
+        />
+        <button className="px-3 py-1 bg-blue-600 text-white" onClick={ask}>
+          Ask
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/Chart.tsx
+++ b/apps/frontend/components/Chart.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { createChart, CandlestickData } from 'lightweight-charts';
+
+export default function Chart({ candles }: { candles: CandlestickData[] }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const chart = createChart(containerRef.current, { height: 300 });
+    const series = chart.addCandlestickSeries();
+    series.setData(candles);
+    return () => {
+      chart.remove();
+    };
+  }, [candles]);
+
+  return <div ref={containerRef} className="w-full" />;
+}

--- a/apps/frontend/components/MetricsGrid.tsx
+++ b/apps/frontend/components/MetricsGrid.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+export default function MetricsGrid({ symbol }: { symbol: string }) {
+  const { data } = useQuery({
+    queryKey: ['quote', symbol],
+    queryFn: async () => {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/api/quote?symbol=${symbol}`);
+      return res.json();
+    },
+  });
+  if (!data) return null;
+  return (
+    <div className="grid grid-cols-2 gap-2 text-sm">
+      <div>Price</div>
+      <div className="font-medium">{data.price.toFixed(2)}</div>
+      <div>Change%</div>
+      <div className={data.change >= 0 ? 'text-green-600' : 'text-red-600'}>
+        {data.change_percent.toFixed(2)}%
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/SymbolSearch.tsx
+++ b/apps/frontend/components/SymbolSearch.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+export default function SymbolSearch() {
+  const router = useRouter();
+  const [symbol, setSymbol] = useState('');
+
+  return (
+    <div className="flex gap-2">
+      <input
+        value={symbol}
+        onChange={(e) => setSymbol(e.target.value)}
+        placeholder="AAPL, MSFT, 2222.SR"
+        className="border px-2 py-1 flex-1"
+      />
+      <button
+        className="px-3 py-1 bg-blue-600 text-white"
+        onClick={() => symbol && router.push(`/symbols/${symbol.toUpperCase()}`)}
+      >
+        Go
+      </button>
+    </div>
+  );
+}

--- a/apps/frontend/components/TrendBadge.tsx
+++ b/apps/frontend/components/TrendBadge.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+const colorMap: Record<string, string> = {
+  Uptrend: 'bg-green-200 text-green-800',
+  Downtrend: 'bg-red-200 text-red-800',
+  Ranging: 'bg-gray-200 text-gray-800',
+};
+
+export default function TrendBadge({ symbol }: { symbol: string }) {
+  const { data } = useQuery({
+    queryKey: ['trend', symbol],
+    queryFn: async () => {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/api/trend?symbol=${symbol}`);
+      return res.json();
+    },
+  });
+
+  if (!data) return <span className="text-gray-500">Loading...</span>;
+  return <span className={`px-2 py-1 rounded ${colorMap[data.label]}`}>{data.label}</span>;
+}

--- a/apps/frontend/env.d.ts
+++ b/apps/frontend/env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly NEXT_PUBLIC_API_BASE: string;
+}
+
+declare namespace NodeJS {
+  interface ProcessEnv extends ImportMetaEnv {}
+}

--- a/apps/frontend/lib/format.ts
+++ b/apps/frontend/lib/format.ts
@@ -1,0 +1,3 @@
+export function formatNumber(n: number, digits = 2): string {
+  return n.toFixed(digits);
+}

--- a/apps/frontend/lib/indicators.client.ts
+++ b/apps/frontend/lib/indicators.client.ts
@@ -1,0 +1,4 @@
+// Placeholder for client-side indicator helpers
+export function dummyIndicator() {
+  return 0;
+}

--- a/apps/frontend/lib/ws.ts
+++ b/apps/frontend/lib/ws.ts
@@ -1,0 +1,4 @@
+export function priceSocket(symbols: string[]): WebSocket {
+  const url = (process.env.NEXT_PUBLIC_API_BASE || '').replace('http', 'ws');
+  return new WebSocket(`${url}/ws/price-stream?symbols=${symbols.join(',')}`);
+}

--- a/apps/frontend/next.config.js
+++ b/apps/frontend/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+module.exports = nextConfig;

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "stock-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@tanstack/react-query": "4.36.1",
+    "lightweight-charts": "4.2.0",
+    "@radix-ui/react-icons": "1.3.0"
+  },
+  "devDependencies": {
+    "typescript": "5.3.3",
+    "tailwindcss": "3.4.1",
+    "postcss": "8.4.31",
+    "autoprefixer": "10.4.16",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.0"
+  }
+}

--- a/apps/frontend/postcss.config.js
+++ b/apps/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/frontend/styles/globals.css
+++ b/apps/frontend/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.9'
+services:
+  backend:
+    build: ./apps/backend
+    env_file: .env
+    ports:
+      - "8000:8000"
+  frontend:
+    build: ./apps/frontend
+    env_file: .env
+    ports:
+      - "3000:3000"
+    environment:
+      NEXT_PUBLIC_API_BASE: http://backend:8000
+    depends_on:
+      - backend
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
## Summary
- add FastAPI backend with Yahoo provider, indicator calculations, and trend engine
- expose AI chat endpoint with SSE streaming
- scaffold Next.js frontend with symbol page, trend badge, metrics grid, and AI chat
- include Docker setup and example environment variables

## Testing
- `pip install fastapi uvicorn[standard] httpx pandas pandas_ta numpy aioredis pytest -q` *(fails: Cannot connect to proxy)*
- `pytest apps/backend/tests/test_trend.py::test_trend_from_candles_uptrend -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a4cba9b7c8832c8358587ba4b4ec9a